### PR TITLE
Possible duplicate popular shelves

### DIFF
--- a/Goodreads/Models/Response/Book.cs
+++ b/Goodreads/Models/Response/Book.cs
@@ -244,7 +244,7 @@ namespace Goodreads.Models.Response
 
             if (shelves != null)
             {
-                PopularShelves = shelves.ToDictionary(x => x.Key, x => x.Value);
+                PopularShelves = shelves.GroupBy(obj => obj.Key).ToDictionary(shelf => shelf.Key, shelf => shelf.Sum(x => x.Value));
             }
         }
     }


### PR DESCRIPTION
In some books popular shelves, you may see a duplicate shelf name, like in "War and Peace" book you would see two "to-read" shelves.
https://www.goodreads.com/book/show/656
![goodreads bug](https://user-images.githubusercontent.com/13505736/41165616-5e2d9c3e-6b53-11e8-8260-ccd196936b5a.PNG)

In this case, the program will throw exception and stops. I merge these same shelves into one.
