### PR TITLE
Adjust Series parsing to populate UserPosition for all series endpoints

### DIFF
--- a/Goodreads.Tests/Endpoints/SeriesEndpointTests.cs
+++ b/Goodreads.Tests/Endpoints/SeriesEndpointTests.cs
@@ -10,7 +10,7 @@ namespace Goodreads.Tests
 
         public SeriesEndpointTests()
         {
-            SeriesEndpoint = Helper.GetAuthClient().Series;
+            SeriesEndpoint = Helper.GetClient().Series;
         }
 
         public class TheGetListByAuthorIdMethod : SeriesEndpointTests
@@ -22,6 +22,9 @@ namespace Goodreads.Tests
 
                 Assert.NotNull(series);
                 Assert.True(series.Count > 0);
+                Assert.NotNull(series[0].Works);
+                Assert.True(series[0].Works.Count > 0);
+                Assert.NotNull(series[0].Works[0].UserPosition);
             }
 
             [Fact]
@@ -42,6 +45,9 @@ namespace Goodreads.Tests
 
                 Assert.NotNull(series);
                 Assert.True(series.Count > 0);
+                Assert.NotNull(series[0].Works);
+                Assert.True(series[0].Works.Count > 0);
+                Assert.NotNull(series[0].Works[0].UserPosition);
             }
 
             [Fact]
@@ -65,6 +71,7 @@ namespace Goodreads.Tests
                 Assert.Equal(expectedSeriesId, series.Id);
                 Assert.NotNull(series.Works);
                 Assert.True(series.Works.Count > 0);
+                Assert.NotNull(series.Works[0].UserPosition);
             }
 
             [Fact]

--- a/Goodreads/Models/Response/Series.cs
+++ b/Goodreads/Models/Response/Series.cs
@@ -81,6 +81,14 @@ namespace Goodreads.Models.Response
             {
                 ParseSeriesWorks(seriesWorksElement);
             }
+            else
+            {
+                seriesWorksElement = element.Parent.Parent;
+                if (seriesWorksElement != null)
+                {
+                    ParseSeriesWorks(seriesWorksElement);
+                }
+            }
         }
 
         /// <summary>
@@ -97,16 +105,18 @@ namespace Goodreads.Models.Response
                 var works = new List<Work>();
                 foreach (var seriesWorkElement in seriesWorkElements)
                 {
+                    var work = new Work();
+
                     var userPosition = seriesWorkElement.ElementAsString("user_position");
+                    work.SetUserPosition(userPosition);
 
                     var workElement = seriesWorkElement.Element("work");
                     if (workElement != null)
                     {
-                        var work = new Work();
                         work.Parse(workElement);
-                        work.SetUserPosition(userPosition);
-                        works.Add(work);
                     }
+
+                    works.Add(work);
                 }
 
                 Works = works;


### PR DESCRIPTION
The Work.UserPosition property isn't being populated for all 3 series endpoints.  The nesting of the <series_works><series_work> tags changes in the [See all series by an author](https://www.goodreads.com/api/index#series.list) and [See all series a work is in](https://www.goodreads.com/api/index#series.work) calls.